### PR TITLE
Add Research & Foundations and Blog sections to homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -681,6 +681,240 @@ ul {
     text-decoration: underline;
 }
 
+/* Research Section */
+.research {
+    background: var(--bg-secondary);
+}
+
+.research-intro {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    gap: 2rem;
+    margin-bottom: 2.5rem;
+}
+
+.research-philosophy h3,
+.research-status h3,
+.research-forward h3 {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent);
+    margin-bottom: 0.75rem;
+}
+
+.research-philosophy p {
+    margin-bottom: 1rem;
+}
+
+.status-list {
+    display: grid;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+}
+
+.status-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    border: 1px solid transparent;
+}
+
+.status-tag.completed {
+    color: #86efac;
+    border-color: rgba(34, 197, 94, 0.4);
+    background: rgba(34, 197, 94, 0.12);
+}
+
+.status-tag.in-progress {
+    color: #fde68a;
+    border-color: rgba(250, 204, 21, 0.4);
+    background: rgba(250, 204, 21, 0.12);
+}
+
+.status-tag.reference {
+    color: #c4b5fd;
+    border-color: rgba(139, 92, 246, 0.4);
+    background: rgba(139, 92, 246, 0.12);
+}
+
+.status-tag.applied {
+    color: #7dd3fc;
+    border-color: rgba(14, 165, 233, 0.4);
+    background: rgba(14, 165, 233, 0.12);
+}
+
+.research-domains {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+}
+
+.research-card {
+    padding: 2rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: all var(--transition-slow);
+}
+
+.research-card.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.research-card h3 {
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    color: var(--text-primary);
+    margin-bottom: 1.5rem;
+}
+
+.research-entry {
+    padding-bottom: 1.5rem;
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.research-entry:last-of-type {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
+.entry-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+}
+
+.entry-title {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    color: var(--text-primary);
+}
+
+.entry-meta {
+    font-size: 0.75rem;
+    color: var(--text-tertiary);
+}
+
+.entry-why,
+.entry-application {
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+}
+
+.research-forward {
+    padding: 2rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-tertiary);
+}
+
+.research-interests {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+}
+
+.research-link a {
+    color: var(--accent);
+}
+
+/* Blog Section */
+.blog-intro {
+    max-width: 720px;
+    margin-bottom: 2rem;
+}
+
+.blog-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.blog-card {
+    padding: 2rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: all var(--transition-slow);
+}
+
+.blog-card.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.blog-pill {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent);
+    margin-bottom: 0.75rem;
+    display: inline-flex;
+}
+
+.blog-card h3 {
+    font-family: var(--font-mono);
+    font-size: 1.05rem;
+    margin-bottom: 0.75rem;
+}
+
+.blog-card p {
+    font-size: 0.85rem;
+    margin-bottom: 0.75rem;
+}
+
+.blog-card ul {
+    display: grid;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+    font-size: 0.8rem;
+}
+
+.blog-card li {
+    display: flex;
+    align-items: baseline;
+}
+
+.blog-card li::before {
+    content: '→';
+    color: var(--text-tertiary);
+    margin-right: 0.5rem;
+}
+
+.blog-status {
+    display: inline-flex;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    background: var(--bg-tertiary);
+}
+
+.blog-link a {
+    color: var(--accent);
+}
+
 /* Education Section */
 .education {
     background: var(--bg-secondary);
@@ -864,6 +1098,10 @@ ul {
         grid-template-columns: 1fr;
     }
 
+    .research-intro {
+        grid-template-columns: 1fr;
+    }
+
     .scroll-indicator {
         display: none;
     }
@@ -925,7 +1163,9 @@ ul {
 .no-js .experience-item,
 .no-js .project-card,
 .no-js .edu-card,
-.no-js .skill-category {
+.no-js .skill-category,
+.no-js .research-card,
+.no-js .blog-card {
     opacity: 1 !important;
     transform: none !important;
     visibility: visible !important;

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
                 <a href="#about">About</a>
                 <a href="#experience">Experience</a>
                 <a href="#projects">Projects</a>
+                <a href="#research">Research</a>
+                <a href="#blog">Blog</a>
                 <a href="#contact">Contact</a>
                 <a href="NevynDuarteResume.pdf" class="nav-cta" target="_blank">Resume ↗</a>
             </div>
@@ -46,6 +48,8 @@
         <a href="#about">About</a>
         <a href="#experience">Experience</a>
         <a href="#projects">Projects</a>
+        <a href="#research">Research</a>
+        <a href="#blog">Blog</a>
         <a href="#contact">Contact</a>
         <a href="NevynDuarteResume.pdf" target="_blank">Resume ↗</a>
     </div>
@@ -374,10 +378,245 @@
     </section>
 
     <!-- Education Section -->
-    <section class="section education">
+    <section id="research" class="section research">
         <div class="section-inner">
             <div class="section-header">
                 <span class="section-number">04</span>
+                <h2 class="section-title">Research & Foundations</h2>
+            </div>
+            <div class="research-intro">
+                <div class="research-philosophy">
+                    <h3>Research philosophy</h3>
+                    <p>
+                        My work is grounded in statistical theory, machine learning research, and systems design. I
+                        actively study academic papers, textbooks, and practitioner research to inform how I design
+                        models, evaluate risk, and build production-ready systems.
+                    </p>
+                    <p>
+                        I organize readings by domain to mirror how I approach problems in practice: theory first,
+                        empirical validation second, and engineering constraints always in view.
+                    </p>
+                </div>
+                <div class="research-status">
+                    <h3>Reading status taxonomy</h3>
+                    <ul class="status-list">
+                        <li><span class="status-tag completed">Completed</span> Core understanding established.</li>
+                        <li><span class="status-tag in-progress">In Progress</span> Actively working through.</li>
+                        <li><span class="status-tag reference">Revisited / Reference</span> Used for quick refreshers.</li>
+                        <li><span class="status-tag applied">Applied in Projects</span> Directly influenced model or system
+                            choices.</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="research-domains">
+                <article class="research-card">
+                    <h3>Statistical Learning & Inference</h3>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">The Elements of Statistical Learning</span>
+                            <span class="entry-meta">Hastie, Tibshirani, Friedman • 2009</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Formalizes bias-variance tradeoffs and model diagnostics for high-stakes
+                            prediction.
+                        </p>
+                        <p class="entry-application">
+                            Application: Used to justify regularization and model complexity in equity prediction
+                            pipelines.
+                        </p>
+                        <span class="status-tag applied">Applied in Projects</span>
+                    </div>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">All of Statistics</span>
+                            <span class="entry-meta">Larry Wasserman • 2004</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Reinforces probabilistic foundations for inference and experimental design.
+                        </p>
+                        <p class="entry-application">
+                            Application: Revisited for uncertainty quantification and hypothesis testing workflows.
+                        </p>
+                        <span class="status-tag reference">Revisited / Reference</span>
+                    </div>
+                </article>
+
+                <article class="research-card">
+                    <h3>Machine Learning & AI</h3>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">Deep Learning</span>
+                            <span class="entry-meta">Goodfellow, Bengio, Courville • 2016</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Provides the theoretical grounding for representation learning and
+                            optimization dynamics.
+                        </p>
+                        <p class="entry-application">
+                            Application: Informs architecture selection and training stability checks for NLP models.
+                        </p>
+                        <span class="status-tag completed">Completed</span>
+                    </div>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">On Calibration of Modern Neural Networks</span>
+                            <span class="entry-meta">Guo et al. • 2017</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Highlights reliability gaps between accuracy and confidence.
+                        </p>
+                        <p class="entry-application">
+                            Application: Evaluating post-hoc calibration for classification confidence in production.
+                        </p>
+                        <span class="status-tag in-progress">In Progress</span>
+                    </div>
+                </article>
+
+                <article class="research-card">
+                    <h3>Quantitative Finance</h3>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">Active Portfolio Management</span>
+                            <span class="entry-meta">Grinold, Kahn • 2000</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Frames alpha generation and risk budgeting in a systematic way.
+                        </p>
+                        <p class="entry-application">
+                            Application: Used to translate research factors into portfolio constraints.
+                        </p>
+                        <span class="status-tag applied">Applied in Projects</span>
+                    </div>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">Advances in Financial Machine Learning</span>
+                            <span class="entry-meta">Marcos López de Prado • 2018</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Focuses on leakage, backtest overfitting, and financial time-series reality.
+                        </p>
+                        <p class="entry-application">
+                            Application: Revisited when designing validation for alternative data models.
+                        </p>
+                        <span class="status-tag reference">Revisited / Reference</span>
+                    </div>
+                </article>
+
+                <article class="research-card">
+                    <h3>Software Engineering & Systems</h3>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">Designing Data-Intensive Applications</span>
+                            <span class="entry-meta">Martin Kleppmann • 2017</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Clarifies tradeoffs in distributed systems and data pipelines.
+                        </p>
+                        <p class="entry-application">
+                            Application: Influenced event-driven ingestion and storage decisions in ML pipelines.
+                        </p>
+                        <span class="status-tag completed">Completed</span>
+                    </div>
+                    <div class="research-entry">
+                        <div class="entry-header">
+                            <span class="entry-title">Hidden Technical Debt in Machine Learning Systems</span>
+                            <span class="entry-meta">Sculley et al. • 2015</span>
+                        </div>
+                        <p class="entry-why">
+                            Why it matters: Explains why production ML systems degrade without rigorous engineering
+                            discipline.
+                        </p>
+                        <p class="entry-application">
+                            Application: Applied to monitoring, validation, and pipeline resilience checks.
+                        </p>
+                        <span class="status-tag applied">Applied in Projects</span>
+                    </div>
+                </article>
+            </div>
+            <div class="research-forward">
+                <h3>Forward-looking research interests</h3>
+                <ul class="research-interests">
+                    <li>Representation learning for structured and tabular data</li>
+                    <li>Model interpretability under regulatory constraints</li>
+                    <li>Time-series forecasting under non-stationarity</li>
+                    <li>Risk-aware optimization and decision-making</li>
+                </ul>
+                <p class="research-link">
+                    Curious how these themes show up in practice? <a href="#projects">See related projects →</a>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <section id="blog" class="section blog">
+        <div class="section-inner">
+            <div class="section-header">
+                <span class="section-number">05</span>
+                <h2 class="section-title">Blog & Technical Commentary</h2>
+            </div>
+            <div class="blog-intro">
+                <p>
+                    Writing is how I pressure-test ideas, document tradeoffs, and translate research into production
+                    decisions. These posts are structured like internal design reviews and research memos.
+                </p>
+            </div>
+            <div class="blog-grid">
+                <article class="blog-card">
+                    <span class="blog-pill">Project Deep Dive</span>
+                    <h3>Designing equity prediction models that survive data drift</h3>
+                    <p>
+                        A walkthrough of how I set up evaluation, leakage checks, and monitoring for alternative data
+                        signals in production research pipelines.
+                    </p>
+                    <ul>
+                        <li>Problem framing and signal selection</li>
+                        <li>Validation strategy for non-stationary data</li>
+                        <li>Engineering guardrails to prevent silent failure</li>
+                    </ul>
+                    <span class="blog-status">Drafting</span>
+                </article>
+
+                <article class="blog-card">
+                    <span class="blog-pill">Research → Practice</span>
+                    <h3>Calibration is not optional in financial classification</h3>
+                    <p>
+                        Translating neural network calibration research into decision-making thresholds for risk-aware
+                        models.
+                    </p>
+                    <ul>
+                        <li>Why accuracy hides confidence issues</li>
+                        <li>Temperature scaling for deployment</li>
+                        <li>Aligning prediction confidence with action</li>
+                    </ul>
+                    <span class="blog-status">Outline in progress</span>
+                </article>
+
+                <article class="blog-card">
+                    <span class="blog-pill">Technical Opinion</span>
+                    <h3>Most ML pipelines fail silently — here is how I audit them</h3>
+                    <p>
+                        A practical checklist for monitoring data contracts, model drift, and feature integrity in
+                        production ML systems.
+                    </p>
+                    <ul>
+                        <li>Pipeline health as a first-class metric</li>
+                        <li>Detecting leakage and training skew</li>
+                        <li>Designing actionable alerts</li>
+                    </ul>
+                    <span class="blog-status">Drafting</span>
+                </article>
+            </div>
+            <p class="blog-link">
+                Want deeper dives? <a href="#contact">Reach out and I can share full drafts.</a>
+            </p>
+        </div>
+    </section>
+
+    <!-- Education Section -->
+    <section class="section education">
+        <div class="section-inner">
+            <div class="section-header">
+                <span class="section-number">06</span>
                 <h2 class="section-title">Education</h2>
             </div>
             <div class="education-grid">
@@ -493,7 +732,9 @@
             });
         }, observerOptions);
 
-        document.querySelectorAll('.experience-item, .project-card, .edu-card, .skill-category').forEach(el => {
+        document.querySelectorAll(
+            '.experience-item, .project-card, .edu-card, .skill-category, .research-card, .blog-card'
+        ).forEach(el => {
             observer.observe(el);
         });
 


### PR DESCRIPTION
### Motivation
- Surface deeper research grounding and methods to signal senior-level ML/quant expertise. 
- Provide a durable blog area for tradeoff analysis and project deep dives to demonstrate thought leadership. 
- Organize readings by domain and status to show applied knowledge rather than a flat reading list.

### Description
- Added new navigation anchors (`#research`, `#blog`) in the top nav and mobile menu and corresponding sections in `index.html` for Research & Foundations and Blog & Technical Commentary. 
- Implemented structured research entries (title, authors, year, why it matters, application) and a reading-status taxonomy (`Completed`, `In Progress`, `Revisited / Reference`, `Applied in Projects`).
- Added multiple example research cards and three starter blog cards, and bumped subsequent section numbering for `Education`.
- Extended the Intersection Observer in the site script to animate `.research-card` and `.blog-card`, and added comprehensive styles in `css/style.css` including badges, card layouts, responsive tweaks, and no-JS fallbacks.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a full-page screenshot via an automated Playwright script, which completed successfully and produced `artifacts/research-blog-section.png`.
- No additional automated linting or unit tests were run for these static content and styling changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69713bc535f083269481440a816861cd)