### PR TITLE
Make skills grid 2-column layout on mobile screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1263,7 +1263,8 @@ ul {
     }
 
     .skills-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
     }
 
     .experience-item {


### PR DESCRIPTION
Update the mobile responsive CSS to display the skills grid in a 2x2 layout
instead of a single column on screens 640px and below. Also reduced the gap
to 1rem for better spacing on smaller screens.