### PR TITLE
Link research titles to sources and add link icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -920,6 +920,25 @@ ul {
     font-family: var(--font-mono);
     font-size: 0.95rem;
     color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.entry-title:hover {
+    color: var(--accent);
+}
+
+.entry-link-icon {
+    font-size: 0.85em;
+    color: var(--text-tertiary);
+    transition: color 0.2s ease;
+}
+
+.entry-title:hover .entry-link-icon {
+    color: var(--accent);
 }
 
 .entry-meta {

--- a/index.html
+++ b/index.html
@@ -562,7 +562,10 @@
                     <h3>Statistical Learning & Inference</h3>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">The Elements of Statistical Learning</span>
+                            <a class="entry-title" href="https://link.springer.com/book/10.1007/978-0-387-84858-7" target="_blank" rel="noopener">
+                                The Elements of Statistical Learning
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Hastie, Tibshirani, Friedman • 2009</span>
                         </div>
                         <p class="entry-why">
@@ -577,7 +580,10 @@
                     </div>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">All of Statistics</span>
+                            <a class="entry-title" href="https://link.springer.com/book/10.1007/978-0-387-21736-9" target="_blank" rel="noopener">
+                                All of Statistics
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Larry Wasserman • 2004</span>
                         </div>
                         <p class="entry-why">
@@ -594,7 +600,10 @@
                     <h3>Machine Learning & AI</h3>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">Deep Learning</span>
+                            <a class="entry-title" href="https://www.deeplearningbook.org/" target="_blank" rel="noopener">
+                                Deep Learning
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Goodfellow, Bengio, Courville • 2016</span>
                         </div>
                         <p class="entry-why">
@@ -608,7 +617,10 @@
                     </div>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">On Calibration of Modern Neural Networks</span>
+                            <a class="entry-title" href="https://arxiv.org/abs/1706.04599" target="_blank" rel="noopener">
+                                On Calibration of Modern Neural Networks
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Guo et al. • 2017</span>
                         </div>
                         <p class="entry-why">
@@ -625,7 +637,10 @@
                     <h3>Quantitative Finance</h3>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">Active Portfolio Management</span>
+                            <a class="entry-title" href="https://www.mhprofessional.com/active-portfolio-management-9780070248826-usa" target="_blank" rel="noopener">
+                                Active Portfolio Management
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Grinold, Kahn • 2000</span>
                         </div>
                         <p class="entry-why">
@@ -638,7 +653,10 @@
                     </div>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">Advances in Financial Machine Learning</span>
+                            <a class="entry-title" href="https://www.wiley.com/en-us/Advances+in+Financial+Machine+Learning-p-9781119482086" target="_blank" rel="noopener">
+                                Advances in Financial Machine Learning
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Marcos López de Prado • 2018</span>
                         </div>
                         <p class="entry-why">
@@ -655,7 +673,10 @@
                     <h3>Software Engineering & Systems</h3>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">Designing Data-Intensive Applications</span>
+                            <a class="entry-title" href="https://dataintensive.net/" target="_blank" rel="noopener">
+                                Designing Data-Intensive Applications
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Martin Kleppmann • 2017</span>
                         </div>
                         <p class="entry-why">
@@ -668,7 +689,10 @@
                     </div>
                     <div class="research-entry">
                         <div class="entry-header">
-                            <span class="entry-title">Hidden Technical Debt in Machine Learning Systems</span>
+                            <a class="entry-title" href="https://proceedings.neurips.cc/paper/2015/hash/86df7dcfd896fcaf2674f757a2463eba-Abstract.html" target="_blank" rel="noopener">
+                                Hidden Technical Debt in Machine Learning Systems
+                                <span class="entry-link-icon" aria-hidden="true">↗</span>
+                            </a>
                             <span class="entry-meta">Sculley et al. • 2015</span>
                         </div>
                         <p class="entry-why">


### PR DESCRIPTION
### Motivation
- Make each research entry directly navigable to its published source and visually indicate outbound links for clarity and discoverability.

### Description
- Replace plain title spans with anchor tags in `index.html` for multiple research entries and add `target="_blank" rel="noopener"` to open sources safely.
- Add a small inline link icon `↗` inside a `span.entry-link-icon` next to each title to communicate outbound navigation.
- Update `css/style.css` to treat `.entry-title` as an inline link with hover color and to style `.entry-link-icon` with a subtle color transition.
- Modified files: `index.html` (multiple title -> link updates) and `css/style.css` (styling for `.entry-title` and `.entry-link-icon`).

### Testing
- Served the site with `python -m http.server 8000` and used a Playwright script to open `/index.html#research` and capture a screenshot, which completed successfully and produced `artifacts/research-links.png`.
- Verified the static changes rendered in the research section and that link anchors appear with the icon and hover styling; no automated unit tests were required for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a20ee4288326a1649edbe990122e)