### PR TITLE
Keep new hero and credentials, revert other positioning updates

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -718,6 +718,25 @@ ul {
     color: var(--accent);
 }
 
+/* Credentials */
+.credentials-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    color: var(--text-secondary);
+    font-size: 0.9375rem;
+}
+
+.credentials-list p {
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.credentials-list p:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
 /* Projects Section */
 .projects-grid {
     display: grid;

--- a/index.html
+++ b/index.html
@@ -63,37 +63,26 @@
     <section class="hero">
         <div class="hero-content">
             <div class="hero-text">
-                <p class="hero-label">Data Scientist & ML Engineer</p>
+                <p class="hero-label">Machine Learning Engineer & Data Scientist</p>
                 <h1 class="hero-title">
-                    <span class="line">Building predictive</span>
-                    <span class="line">models at the</span>
-                    <span class="line"><em>intersection</em> of</span>
-                    <span class="line">ML & finance</span>
+                    <span class="line">Building intelligent</span>
+                    <span class="line">systems for</span>
+                    <span class="line">real-world impact</span>
                 </h1>
                 <p class="hero-description">
-                    I develop machine learning systems and quantitative models for financial applications.
-                    Currently pursuing my M.S. in Data Science at CU Boulder while building tools that
-                    turn alternative data into actionable insights.
+                    I design and deploy machine learning systems spanning computer vision, NLP, large-scale data
+                    pipelines, and quantitative modeling—grounded in rigorous statistics and engineered for
+                    production.
                 </p>
                 <div class="hero-cta">
-                    <a href="#experience" class="btn btn-primary">View my work</a>
-                    <a href="#contact" class="btn btn-secondary">Get in touch</a>
+                    <a href="#projects" class="btn btn-primary">View Projects</a>
+                    <a href="#research" class="btn btn-secondary">Research & Systems</a>
                 </div>
             </div>
             <div class="hero-visual">
                 <div class="profile-container">
                     <img src="images/profilepic.png" alt="Nevyn Duarte" class="profile-img">
                     <div class="profile-accent"></div>
-                </div>
-                <div class="hero-stats">
-                    <div class="stat">
-                        <span class="stat-number">5+</span>
-                        <span class="stat-label">Years Experience</span>
-                    </div>
-                    <div class="stat">
-                        <span class="stat-number">$10B+</span>
-                        <span class="stat-label">AUM Supported</span>
-                    </div>
                 </div>
             </div>
         </div>
@@ -453,11 +442,27 @@
         </div>
     </section>
 
+    <section id="credentials" class="section credentials">
+        <div class="section-inner">
+            <div class="section-header">
+                <span class="section-number">04</span>
+                <h2 class="section-title">Additional Academic & Technical Credentials</h2>
+            </div>
+            <div class="credentials-list">
+                <p>Regis High School — New York City</p>
+                <p>Algorithms for Searching, Sorting, and Indexing — University of Colorado Boulder</p>
+                <p>Dynamic Programming & Greedy Algorithms — University of Colorado Boulder</p>
+                <p>Trees and Graphs — University of Colorado Boulder</p>
+                <p>Data Science Foundations: Data Structures & Algorithms — Coursera</p>
+            </div>
+        </div>
+    </section>
+
     <!-- Projects Section -->
     <section id="projects" class="section projects">
         <div class="section-inner">
             <div class="section-header">
-                <span class="section-number">04</span>
+                <span class="section-number">05</span>
                 <h2 class="section-title">Projects</h2>
             </div>
             <div class="filter-container">
@@ -530,7 +535,7 @@
     <section id="research" class="section research">
         <div class="section-inner">
             <div class="section-header">
-                <span class="section-number">05</span>
+                <span class="section-number">06</span>
                 <h2 class="section-title">Research & Foundations</h2>
             </div>
             <div class="research-intro">
@@ -700,7 +705,7 @@
     <section id="blog" class="section blog">
         <div class="section-inner">
             <div class="section-header">
-                <span class="section-number">06</span>
+                <span class="section-number">07</span>
                 <h2 class="section-title">Blog & Technical Commentary</h2>
             </div>
             <div class="blog-intro">


### PR DESCRIPTION
### Motivation
- The change preserves the preferred new landing hero and the Additional Academic & Technical Credentials while undoing broader site repositioning that introduced unwanted copy and structural changes.
- Restore the original site structure and in-page navigation while keeping the hero focused on ML systems and the new credentials section.

### Description
- Updated the landing hero in `index.html` with new label, title, description, and CTAs pointing to `#projects` and `#research` and removed the hero stats block.
- Added an `Additional Academic & Technical Credentials` section to `index.html` and included corresponding styles in `css/style.css` under the `.credentials-list` rules.
- Removed the standalone `research-and-systems.html` file and restored navigation to the original in-page `#research` anchor and original copy for non-hero sections by reverting non-hero positioning edits.
- Committed the rollback as a single change set titled `Revert non-hero positioning changes`.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to visit `http://127.0.0.1:8000/index.html` and capture a full-page screenshot, which completed successfully and produced `artifacts/homepage-updated.png`.
- No unit tests apply to content updates; the visual smoke test (screenshot) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730d0caa40832687183d227010ee4a)