### PR TITLE
Expand experience and education details

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -621,24 +621,6 @@ ul {
     gap: 2rem;
 }
 
-.experience-group {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-}
-
-.experience-group + .experience-group {
-    margin-top: 1.5rem;
-}
-
-.experience-group-title {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--accent-purple);
-}
-
 .experience-item {
     padding: 2rem;
     background: var(--bg-card);
@@ -663,10 +645,24 @@ ul {
 
 .exp-logo {
     flex-shrink: 0;
-    width: 100px;
+    width: 115px;
     height: auto;
     opacity: 0.9;
     transition: opacity var(--transition-base);
+}
+
+.exp-logo-placeholder {
+    height: 115px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
 .experience-item:hover .exp-logo {
@@ -736,85 +732,11 @@ ul {
     color: var(--accent);
 }
 
-/* Credentials */
-.credentials-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    color: var(--text-secondary);
-    font-size: 0.9375rem;
-}
-
-.credentials-list p {
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid var(--border);
-}
-
-.credentials-list p:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-}
-
 /* Projects Section */
 .projects-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
     gap: 1.5rem;
-}
-
-/* Research & Systems Page */
-.research-systems-hero .section-title {
-    font-size: clamp(2.5rem, 5vw, 3.5rem);
-}
-
-.research-systems-intro {
-    max-width: 720px;
-    color: var(--text-secondary);
-    font-size: 1rem;
-}
-
-.research-systems-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
-}
-
-.research-system-card {
-    padding: 2rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    opacity: 0;
-    transform: translateY(20px);
-    transition: all var(--transition-slow);
-}
-
-.research-system-card.visible {
-    opacity: 1;
-    transform: translateY(0);
-}
-
-.research-system-card h2 {
-    font-size: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.research-system-row + .research-system-row {
-    margin-top: 1rem;
-}
-
-.research-system-row h3 {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--accent);
-    margin-bottom: 0.35rem;
-}
-
-.research-system-row p {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
 }
 
 .project-card {
@@ -1175,7 +1097,7 @@ ul {
 
 .edu-logo {
     flex-shrink: 0;
-    width: 120px;
+    width: 138px;
     height: auto;
     opacity: 0.9;
     transition: opacity var(--transition-base);
@@ -1187,6 +1109,28 @@ ul {
 
 .edu-content {
     flex: 1;
+}
+
+.edu-card--minor {
+    padding: 1.25rem;
+    gap: 1rem;
+}
+
+.edu-card--minor .edu-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.edu-minor-title {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    color: var(--text-primary);
+}
+
+.edu-minor-school {
+    font-size: 0.8125rem;
+    color: var(--text-tertiary);
 }
 
 .edu-school {

--- a/index.html
+++ b/index.html
@@ -5,16 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
-        content="Nevyn Duarte is a Machine Learning Engineer and Data Scientist focused on applied AI, ML systems, and production-ready modeling.">
-    <meta name="keywords"
-        content="Machine Learning Engineer, Data Scientist, AI Engineer, Applied Machine Learning, ML Systems">
-    <meta property="og:title" content="Nevyn Duarte | Machine Learning Engineer & Data Scientist">
-    <meta property="og:description"
-        content="Machine Learning Engineer and Data Scientist building applied AI systems, ML pipelines, and research-driven solutions.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://nevynduarte.github.io/">
-    <meta property="og:image" content="images/profilepic.png">
-    <title>Nevyn Duarte | Machine Learning Engineer & Data Scientist</title>
+        content="Nevyn Duarte - Data Scientist & ML Engineer specializing in quantitative finance, machine learning, and predictive modeling.">
+    <title>Nevyn Duarte | Data Scientist & ML Engineer</title>
     <link rel="icon" href="images/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="images/favicon.ico" sizes="any">
     <link rel="icon" type="image/png" href="images/favicon-32.png" sizes="32x32">
@@ -43,7 +35,7 @@
                 <a href="#experience">Experience</a>
                 <a href="#education">Education</a>
                 <a href="#projects">Projects</a>
-                <a href="research-and-systems.html">Research & Systems</a>
+                <a href="#research">Research</a>
                 <a href="#blog">Blog</a>
                 <a href="#contact">Contact</a>
                 <a href="NevynDuarteResume.pdf" class="nav-cta" target="_blank">Resume ↗</a>
@@ -61,7 +53,7 @@
         <a href="#experience">Experience</a>
         <a href="#education">Education</a>
         <a href="#projects">Projects</a>
-        <a href="research-and-systems.html">Research & Systems</a>
+        <a href="#research">Research</a>
         <a href="#blog">Blog</a>
         <a href="#contact">Contact</a>
         <a href="NevynDuarteResume.pdf" target="_blank">Resume ↗</a>
@@ -71,26 +63,38 @@
     <section class="hero">
         <div class="hero-content">
             <div class="hero-text">
-                <p class="hero-label">Machine Learning Engineer & Data Scientist</p>
+                <p class="hero-label">Data Scientist & ML Engineer</p>
                 <h1 class="hero-title">
                     <span class="line">Building intelligent</span>
                     <span class="line">systems for</span>
-                    <span class="line">real-world impact</span>
+                    <span class="line">real-world</span>
+                    <span class="line">impact</span>
                 </h1>
                 <p class="hero-description">
-                    I design and deploy machine learning systems spanning computer vision, NLP, large-scale data
-                    pipelines, and quantitative modeling—grounded in rigorous statistics and engineered for
-                    production.
+                    I build data science and machine learning systems and quantitative models for financial applications.
+                    At M Science (Jefferies), I applied these skills to predictive equity modeling, alternative-data
+                    research, NLP-driven document analysis, risk analytics, and automated reporting pipelines, while
+                    pursuing my M.S. in Data Science at CU Boulder.
                 </p>
                 <div class="hero-cta">
-                    <a href="#projects" class="btn btn-primary">View Projects</a>
-                    <a href="research-and-systems.html" class="btn btn-secondary">Research & Systems</a>
+                    <a href="#experience" class="btn btn-primary">View my work</a>
+                    <a href="#contact" class="btn btn-secondary">Get in touch</a>
                 </div>
             </div>
             <div class="hero-visual">
                 <div class="profile-container">
                     <img src="images/profilepic.png" alt="Nevyn Duarte" class="profile-img">
                     <div class="profile-accent"></div>
+                </div>
+                <div class="hero-stats">
+                    <div class="stat">
+                        <span class="stat-number">5+</span>
+                        <span class="stat-label">Years Experience</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-number">$10B+</span>
+                        <span class="stat-label">AUM Supported</span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -110,51 +114,60 @@
             <div class="about-content">
                 <div class="about-text">
                     <p class="about-lead">
-                        I'm a Machine Learning Engineer and Data Scientist focused on building applied AI systems that
-                        move from research to production. I'm currently an M.S. Data Science candidate at the
-                        University of Colorado Boulder (GPA 3.72), with a focus on machine learning, applied AI, NLP,
-                        computer vision, statistical modeling, and distributed systems.
+                        I'm a Data Scientist with deep experience in quantitative finance,
+                        statistical modeling, and machine learning engineering.
                     </p>
                     <p>
-                        At UT Austin's Building-Wide Intelligence lab, I researched robotics and computer vision,
-                        implementing DeepSORT with Triplet Loss for trajectory-based person-following in crowded
-                        environments. I built autonomous navigation in Python, C++, and ROS, and was recognized with
-                        the UT CNS Award for Excellence in Computer Science.
+                        My background spans equity research at Jefferies, risk analysis supporting
+                        hedge funds with $10B+ AUM, and deploying NLP models at scale. I've built
+                        predictive models trained on millions of financial transactions and automated
+                        workflows that cut reporting cycles from quarterly to monthly.
                     </p>
                     <p>
-                        Professionally, I've applied ML and data systems across semiconductors (AMD), applied AI/NLP
-                        (Perceive Now), and quantitative research at M Science. Finance informs my quantitative rigor,
-                        but my primary focus is designing ML/AI systems that scale across industries.
+                        I hold a B.S. in Mathematics from UT Austin and am currently completing
+                        my M.S. in Data Science at CU Boulder, where I'm deepening my expertise
+                        in deep learning, parallel computing, and advanced statistical methods.
                     </p>
                 </div>
                 <div class="skills-grid">
                     <div class="skill-category">
-                        <h3>Machine Learning & AI</h3>
+                        <h3>ML & AI</h3>
                         <ul>
-                            <li>Supervised & Unsupervised Learning</li>
-                            <li>Deep Learning (PyTorch, TensorFlow)</li>
-                            <li>NLP (Transformers, HuggingFace)</li>
-                            <li>Anomaly Detection</li>
-                            <li>Metric Learning</li>
-                            <li>Model Evaluation & Experimental Design</li>
+                            <li>PyTorch</li>
+                            <li>TensorFlow</li>
+                            <li>scikit-learn</li>
+                            <li>HuggingFace</li>
+                            <li>XGBoost</li>
                         </ul>
                     </div>
                     <div class="skill-category">
-                        <h3>Data & Systems</h3>
+                        <h3>Data Engineering</h3>
                         <ul>
-                            <li>Python, SQL, PySpark</li>
+                            <li>PySpark</li>
                             <li>Databricks</li>
-                            <li>AWS (Lambda, SQS, SNS)</li>
-                            <li>Distributed & Parallel Computing</li>
-                            <li>Data Pipelines & Automation</li>
+                            <li>SQL</li>
+                            <li>AWS</li>
+                            <li>Docker</li>
                         </ul>
                     </div>
                     <div class="skill-category">
-                        <h3>Engineering</h3>
+                        <h3>Languages</h3>
                         <ul>
-                            <li>Docker, Git</li>
-                            <li>Go, C++, R</li>
-                            <li>API-driven system design</li>
+                            <li>Python</li>
+                            <li>R</li>
+                            <li>Go</li>
+                            <li>C++</li>
+                            <li>Bash</li>
+                        </ul>
+                    </div>
+                    <div class="skill-category">
+                        <h3>Finance Tools</h3>
+                        <ul>
+                            <li>FactSet</li>
+                            <li>Bloomberg</li>
+                            <li>Tableau</li>
+                            <li>Power BI</li>
+                            <li>JMP</li>
                         </ul>
                     </div>
                 </div>
@@ -167,7 +180,7 @@
         <div class="section-inner">
             <div class="section-header">
                 <span class="section-number">02</span>
-                <h2 class="section-title">Selected Experience (Machine Learning & Data Systems)</h2>
+                <h2 class="section-title">Experience</h2>
             </div>
             <div class="filter-container">
                 <label for="experience-filter" class="filter-label">Filter by skill:</label>
@@ -176,112 +189,352 @@
                 </select>
             </div>
             <div class="experience-list">
-                <div class="experience-group">
-                    <h3 class="experience-group-title">Machine Learning & Research</h3>
-                    <article class="experience-item">
-                        <img src="images/logos/utresearch-white-purple.png" alt="UT Austin Research" class="exp-logo">
-                        <div class="exp-content">
-                            <div class="exp-header">
-                                <div class="exp-company">
-                                    <h3>UT Austin Research</h3>
-                                    <span class="exp-role">Undergraduate Research Associate — BWI Project</span>
-                                </div>
-                                <span class="exp-date">Jan 2019 – Jun 2020</span>
+                <article class="experience-item">
+                    <img src="images/logos/mscience-white-purple.png" alt="M Science" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>M Science (Jefferies)</h3>
+                                <span class="exp-role">Quantitative Equity Research Associate</span>
                             </div>
-                            <ul class="exp-details">
-                                <li>Led ML research for robotics and computer vision, focused on person-following in crowded environments</li>
-                                <li>Implemented DeepSORT tracking with metric learning using Triplet Loss for robust identity tracking</li>
-                                <li>Built autonomous navigation workflows in Python, C++, and ROS</li>
-                                <li>Recognized with the UT CNS Award for Excellence in Computer Science</li>
-                            </ul>
-                            <div class="exp-tags">
-                                <span>Computer Vision</span>
-                                <span>DeepSORT</span>
-                                <span>Metric Learning</span>
-                                <span>Python</span>
-                                <span>C++</span>
-                                <span>ROS</span>
-                            </div>
+                            <span class="exp-date">Sep 2022 – Feb 2023</span>
                         </div>
-                    </article>
-                </div>
+                        <ul class="exp-details">
+                            <li>Developed predictive equity models using PySpark and SQL on Databricks, analyzing millions of transactions</li>
+                            <li>Produced data-driven research reports with FactSet and REST APIs, accelerating report cycles from quarterly to monthly</li>
+                            <li>Automated data extraction and reporting workflows, enhancing team efficiency by up to 25%</li>
+                            <li>Collaborated with senior analysts to deliver alternative-data insights for institutional investors</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>PySpark</span>
+                            <span>Databricks</span>
+                            <span>Python</span>
+                            <span>SQL</span>
+                            <span>FactSet API</span>
+                        </div>
+                    </div>
+                </article>
 
-                <div class="experience-group">
-                    <h3 class="experience-group-title">Applied Machine Learning & Data Science</h3>
-                    <article class="experience-item">
-                        <img src="images/logos/amd-white-purple.png" alt="AMD" class="exp-logo">
-                        <div class="exp-content">
-                            <div class="exp-header">
-                                <div class="exp-company">
-                                    <h3>Advanced Micro Devices (AMD)</h3>
-                                    <span class="exp-role">Yield Analysis Intern → Product Development Intern</span>
-                                </div>
-                                <span class="exp-date">Aug 2021 – May 2022</span>
+                <article class="experience-item">
+                    <img src="images/logos/goodfill-white-purple.png" alt="Goodfill" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Goodfill</h3>
+                                <span class="exp-role">Backend Software Engineer Consultant</span>
                             </div>
-                            <ul class="exp-details">
-                                <li>Researched nearest-neighbor ML anomaly detection on 100k+ wafer samples</li>
-                                <li>Built yield analysis dashboards in Power BI for cross-functional engineering teams</li>
-                                <li>Automated failure alerts and statistical monitoring with Python and JMP</li>
-                            </ul>
-                            <div class="exp-tags">
-                                <span>Machine Learning</span>
-                                <span>Python</span>
-                                <span>JMP</span>
-                                <span>Power BI</span>
-                            </div>
+                            <span class="exp-date">Jul 2022 – Sep 2022</span>
                         </div>
-                    </article>
+                        <ul class="exp-details">
+                            <li>Developed investor onboarding and FINRA record verification systems using Python</li>
+                            <li>Engineered backend services in Go, integrating AWS technologies and Interactive Brokers APIs</li>
+                            <li>Deployed containerized infrastructure with Docker to improve scalability and reliability</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Go</span>
+                            <span>AWS Lambda</span>
+                            <span>Docker</span>
+                            <span>IB Gateway</span>
+                        </div>
+                    </div>
+                </article>
 
-                    <article class="experience-item">
-                        <img src="images/logos/perceivenow-white-purple.png" alt="PerceiveNow" class="exp-logo">
-                        <div class="exp-content">
-                            <div class="exp-header">
-                                <div class="exp-company">
-                                    <h3>PerceiveNow</h3>
-                                    <span class="exp-role">Data Analyst</span>
-                                </div>
-                                <span class="exp-date">Jul 2022 – Oct 2022</span>
+                <article class="experience-item">
+                    <img src="images/logos/perceivenow-white-purple.png" alt="PerceiveNow" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>PerceiveNow</h3>
+                                <span class="exp-role">Data Analyst</span>
                             </div>
-                            <ul class="exp-details">
-                                <li>Deployed HuggingFace NLP models on AWS Lambda for large-scale document processing</li>
-                                <li>Streamlined Python pipelines for faster research ingestion and classification</li>
-                            </ul>
-                            <div class="exp-tags">
-                                <span>HuggingFace</span>
-                                <span>NLP</span>
-                                <span>AWS Lambda</span>
-                                <span>Python</span>
-                            </div>
+                            <span class="exp-date">Jul 2022 – Oct 2022</span>
                         </div>
-                    </article>
-                </div>
+                        <ul class="exp-details">
+                            <li>Implemented HuggingFace NLP models for zero-shot classification, summarization, and entity extraction on AWS Lambda</li>
+                            <li>Streamlined REST API pipelines in Python and Jupyter, cutting report generation time by 18%</li>
+                            <li>Enhanced large-scale text processing pipelines, reducing operating costs by 12%</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>HuggingFace</span>
+                            <span>NLP</span>
+                            <span>AWS Lambda</span>
+                            <span>Python</span>
+                        </div>
+                    </div>
+                </article>
 
-                <div class="experience-group">
-                    <h3 class="experience-group-title">Quantitative & Data-Intensive Systems (Condensed)</h3>
-                    <article class="experience-item">
-                        <img src="images/logos/mscience-white-purple.png" alt="M Science" class="exp-logo">
-                        <div class="exp-content">
-                            <div class="exp-header">
-                                <div class="exp-company">
-                                    <h3>M Science (Jefferies)</h3>
-                                    <span class="exp-role">Quantitative Equity Research Associate</span>
-                                </div>
-                                <span class="exp-date">Oct 2022 – Mar 2023</span>
+                <article class="experience-item">
+                    <img src="images/logos/citco-white-purple.png" alt="Citco" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Citco</h3>
+                                <span class="exp-role">Risk Analysis Intern</span>
                             </div>
-                            <ul class="exp-details">
-                                <li>Built predictive models with PySpark and SQL on Databricks using large alternative datasets</li>
-                                <li>Automated research pipelines for scalable feature generation and analysis</li>
-                                <li>Partnered with research teams to translate model outputs into repeatable workflows</li>
-                            </ul>
-                            <div class="exp-tags">
-                                <span>PySpark</span>
-                                <span>Databricks</span>
-                                <span>Python</span>
-                                <span>SQL</span>
-                            </div>
+                            <span class="exp-date">May 2022 – Jul 2022</span>
                         </div>
-                    </article>
-                </div>
+                        <ul class="exp-details">
+                            <li>Automated AIFMD and Form PF reporting for 20+ hedge funds using Python, SQL, and PySpark</li>
+                            <li>Supported internal risk and valuation models for portfolios exceeding $10B AUM</li>
+                            <li>Developed VBA and Excel analytics dashboards to improve fund performance reporting</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>PySpark</span>
+                            <span>Risk Modeling</span>
+                            <span>SQL</span>
+                            <span>VBA</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <img src="images/logos/amd-white-purple.png" alt="AMD" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Advanced Micro Devices (AMD)</h3>
+                                <span class="exp-role">Yield Analysis Intern</span>
+                            </div>
+                            <span class="exp-date">Jan 2022 – Jun 2022</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Designed an adaptive outlier detection algorithm using nearest-neighbor ML to flag yield anomalies across 100k+ wafer samples</li>
+                            <li>Visualized trends in JMP and Python to improve yield analysis accuracy</li>
+                            <li>Built Power BI dashboards adopted by 20+ engineers to track production test results</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Machine Learning</span>
+                            <span>Python</span>
+                            <span>JMP</span>
+                            <span>Power BI</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <img src="images/logos/amd-white-purple.png" alt="AMD" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Advanced Micro Devices (AMD)</h3>
+                                <span class="exp-role">Product Development Intern</span>
+                            </div>
+                            <span class="exp-date">Aug 2021 – Dec 2021</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Built real-time Power BI dashboards to monitor lab testing machine status and work orders</li>
+                            <li>Integrated 12+ data sources, including Snowflake and MySQL, using Power Automate and Beautiful Soup</li>
+                            <li>Automated reporting and anomaly detection workflows in Python to identify machine failures</li>
+                            <li>Created shipping and inventory tracking workflows that improved operational efficiency by ~15%</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Power BI</span>
+                            <span>Python</span>
+                            <span>Snowflake</span>
+                            <span>Automation</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <img src="images/logos/bny_mellon-white-purple.png" alt="BNY Mellon" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>BNY Mellon</h3>
+                                <span class="exp-role">Summer Markets Data Analytics Analyst</span>
+                            </div>
+                            <span class="exp-date">Jun 2021 – Aug 2021</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Designed Tableau, Excel, and Python dashboards for Sales and Analytics teams to visualize client data</li>
+                            <li>Developed automation scripts in VBA and Python to reduce manual reporting time</li>
+                            <li>Contributed to a centralized data warehouse to improve data accuracy across teams</li>
+                            <li>Partnered with cross-functional teams to streamline client liquidity and performance analysis</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Tableau</span>
+                            <span>Python</span>
+                            <span>Data Analytics</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <div class="exp-logo exp-logo-placeholder" role="img" aria-label="Chipotle Mexican Grill logo">
+                        CMG
+                    </div>
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Chipotle Mexican Grill</h3>
+                                <span class="exp-role">Grill Chef, Line Server, Prep Team, Cashier</span>
+                            </div>
+                            <span class="exp-date">Jul 2020 – Jul 2021</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Prepared and served food in accordance with national safety and quality standards</li>
+                            <li>Collaborated with team members to maintain consistent service quality in a fast-paced environment</li>
+                            <li>Engaged with customers as a cashier to ensure a positive dining experience</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Customer Service</span>
+                            <span>Teamwork</span>
+                            <span>Operations</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <img src="images/logos/utresearch-white-purple.png" alt="UT Austin Research" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>UT Austin Research</h3>
+                                <span class="exp-role">Undergraduate Research Associate — BWI Project</span>
+                            </div>
+                            <span class="exp-date">Jan 2019 – Jun 2020</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Researched robotics and computer vision for trajectory-based person-following systems</li>
+                            <li>Co-authored a paper integrating DeepSORT tracking with Google’s Triplet Loss for improved accuracy</li>
+                            <li>Programmed autonomy and navigation stacks in Python, C++, and ROS</li>
+                            <li>Recognized with the UT CNS Award for Excellence in Computer Science at the Undergraduate Research Forum</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Computer Vision</span>
+                            <span>Python</span>
+                            <span>C++</span>
+                            <span>ROS</span>
+                            <span>DeepSORT</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <img src="images/logos/order-white-purple.png" alt="Negotiatus" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Negotiatus</h3>
+                                <span class="exp-role">Software Engineering Intern</span>
+                            </div>
+                            <span class="exp-date">Jun 2017 – Aug 2017</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Built interactive D3.js and AJAX dashboards for real-time sales data visualization</li>
+                            <li>Migrated CRM data from HubSpot to Salesforce through API integrations and automated scripts</li>
+                            <li>Enhanced front-end features with HTML, CSS, and JavaScript, plus RSpec tests in Ruby on Rails</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>D3.js</span>
+                            <span>Ruby on Rails</span>
+                            <span>JavaScript</span>
+                            <span>Salesforce API</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <img src="images/logos/stae-white-purple.png?v=2" alt="stae" class="exp-logo">
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>stae</h3>
+                                <span class="exp-role">Software Engineering Intern</span>
+                            </div>
+                            <span class="exp-date">Jun 2016 – Sep 2016</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Designed interactive web dashboards with PostgreSQL, React, D3.js, and Node.js for client data visualization</li>
+                            <li>Redesigned company web pages to align with updated product interfaces and branding</li>
+                            <li>Authored comprehensive developer documentation on Linux systems for team onboarding</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>React</span>
+                            <span>D3.js</span>
+                            <span>Node.js</span>
+                            <span>PostgreSQL</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <div class="exp-logo exp-logo-placeholder" role="img" aria-label="Beyond Coding logo">
+                        BC
+                    </div>
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Beyond Coding</h3>
+                                <span class="exp-role">Summer Student</span>
+                            </div>
+                            <span class="exp-date">Jul 2016 – Aug 2016</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Participated in software engineering workshops hosted by leading tech companies</li>
+                            <li>Built practical knowledge of agile development practices and technical interviewing</li>
+                            <li>Engaged in networking sessions and mock interviews with professional developers</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Agile</span>
+                            <span>Software Engineering</span>
+                            <span>Professional Development</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <div class="exp-logo exp-logo-placeholder" role="img" aria-label="Google logo">
+                        Google
+                    </div>
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Google</h3>
+                                <span class="exp-role">Web Development Boot Camp</span>
+                            </div>
+                            <span class="exp-date">Jun 2016</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Selected for a competitive web development bootcamp at Google NYC headquarters</li>
+                            <li>Built a full-stack web app with HTML, CSS, JavaScript, jQuery, SQLite3, and Python (Bottle)</li>
+                            <li>Implemented authentication and deployed the app on PythonAnywhere</li>
+                            <li>Enhanced UI with Bootstrap and Skeleton frameworks</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>JavaScript</span>
+                            <span>Python</span>
+                            <span>SQLite</span>
+                            <span>Bootstrap</span>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="experience-item">
+                    <div class="exp-logo exp-logo-placeholder" role="img" aria-label="Peopli logo">
+                        Peopli
+                    </div>
+                    <div class="exp-content">
+                        <div class="exp-header">
+                            <div class="exp-company">
+                                <h3>Peopli</h3>
+                                <span class="exp-role">Software Engineering and Marketing Intern</span>
+                            </div>
+                            <span class="exp-date">Feb 2016 – May 2016</span>
+                        </div>
+                        <ul class="exp-details">
+                            <li>Supported early-stage marketing and product strategy for a Brooklyn technology startup</li>
+                            <li>Developed promotional content and improved the website to attract new users</li>
+                            <li>Conducted research to inform outreach strategies and organized marketing plans</li>
+                        </ul>
+                        <div class="exp-tags">
+                            <span>Marketing</span>
+                            <span>Product Strategy</span>
+                            <span>Web Content</span>
+                        </div>
+                    </div>
+                </article>
             </div>
         </div>
     </section>
@@ -297,13 +550,16 @@
                 <div class="edu-card">
                     <img src="images/logos/cuboulder-white-purple.png" alt="University of Colorado Boulder" class="edu-logo">
                     <div class="edu-content">
-                        <div class="edu-degree">M.S. Data Science</div>
+                        <div class="edu-degree">Master of Science — Data Science</div>
                         <div class="edu-school">University of Colorado Boulder</div>
-                        <div class="edu-date">2023 – Present</div>
+                        <div class="edu-date">2023 – 2026</div>
                         <div class="edu-gpa">GPA: 3.72</div>
                         <p class="edu-courses">
-                            Machine Learning & Deep Learning, Natural Language Processing, Statistical Inference &
-                            Experimental Design, Parallel & Distributed Computing, Data Mining & Big Data Architecture
+                            Deep Learning, Natural Language Processing, Applied Artificial Intelligence, Unsupervised Learning,
+                            Machine Learning (Supervised), Modern Regression Analysis in R, Regression and Classification,
+                            Statistical Inference, ANOVA and Experimental Design, Parallel Computing for Data Science,
+                            Big Data Architecture, Data Mining Methods, Relational Database Design, SQL for Data Science,
+                            Algorithms for Searching and Sorting, Cybersecurity, and Ethical Issues in Data Science
                         </p>
                     </div>
                 </div>
@@ -314,27 +570,44 @@
                         <div class="edu-degree">B.S. Mathematics</div>
                         <div class="edu-date">2018 – 2022</div>
                         <p class="edu-courses">
-                            Linear Algebra, Real Analysis, Probability & Statistics, Autonomous Robotics & Applied ML
-                            Research
+                            Advanced Research in Autonomous Intelligent Robotics, AI Robotics Research, Applied Statistics in R,
+                            Statistics &amp; Probability for Computer Science, Matrices &amp; Linear Algebra, Real Analysis,
+                            Advanced Calculus for Applications
                         </p>
                     </div>
                 </div>
-            </div>
-        </div>
-    </section>
-
-    <section id="credentials" class="section credentials">
-        <div class="section-inner">
-            <div class="section-header">
-                <span class="section-number">04</span>
-                <h2 class="section-title">Additional Academic & Technical Credentials</h2>
-            </div>
-            <div class="credentials-list">
-                <p>Regis High School — New York City</p>
-                <p>Algorithms for Searching, Sorting, and Indexing — University of Colorado Boulder</p>
-                <p>Dynamic Programming & Greedy Algorithms — University of Colorado Boulder</p>
-                <p>Trees and Graphs — University of Colorado Boulder</p>
-                <p>Data Science Foundations: Data Structures & Algorithms — Coursera</p>
+                <div class="edu-card">
+                    <img src="images/logos/regis-white-purple.png" alt="Regis High School" class="edu-logo">
+                    <div class="edu-content">
+                        <div class="edu-school">Regis High School</div>
+                        <div class="edu-degree">High School Diploma</div>
+                        <div class="edu-date">2014 – 2018</div>
+                    </div>
+                </div>
+                <div class="edu-card edu-card--minor">
+                    <div class="edu-content">
+                        <div class="edu-minor-title">Trees and Graphs: Basics</div>
+                        <div class="edu-minor-school">University of Colorado Boulder</div>
+                    </div>
+                </div>
+                <div class="edu-card edu-card--minor">
+                    <div class="edu-content">
+                        <div class="edu-minor-title">Algorithms for Searching, Sorting, and Indexing</div>
+                        <div class="edu-minor-school">University of Colorado Boulder</div>
+                    </div>
+                </div>
+                <div class="edu-card edu-card--minor">
+                    <div class="edu-content">
+                        <div class="edu-minor-title">Dynamic Programming, Greedy Algorithms</div>
+                        <div class="edu-minor-school">University of Colorado Boulder</div>
+                    </div>
+                </div>
+                <div class="edu-card edu-card--minor">
+                    <div class="edu-content">
+                        <div class="edu-minor-title">Data Science Foundations: Data Structures and Algorithms Specialization</div>
+                        <div class="edu-minor-school">Coursera</div>
+                    </div>
+                </div>
             </div>
         </div>
     </section>
@@ -343,7 +616,7 @@
     <section id="projects" class="section projects">
         <div class="section-inner">
             <div class="section-header">
-                <span class="section-number">05</span>
+                <span class="section-number">04</span>
                 <h2 class="section-title">Projects</h2>
             </div>
             <div class="filter-container">
@@ -416,7 +689,7 @@
     <section id="research" class="section research">
         <div class="section-inner">
             <div class="section-header">
-                <span class="section-number">06</span>
+                <span class="section-number">05</span>
                 <h2 class="section-title">Research & Foundations</h2>
             </div>
             <div class="research-intro">
@@ -610,7 +883,7 @@
     <section id="blog" class="section blog">
         <div class="section-inner">
             <div class="section-header">
-                <span class="section-number">07</span>
+                <span class="section-number">06</span>
                 <h2 class="section-title">Blog & Technical Commentary</h2>
             </div>
             <div class="blog-intro">
@@ -677,8 +950,8 @@
             <div class="contact-content">
                 <h2 class="contact-title">Let's connect</h2>
                 <p class="contact-text">
-                    I'm currently exploring opportunities in machine learning engineering, data science, and applied
-                    AI systems. If you're building something research-driven, I'd love to hear about it.
+                    I'm currently exploring opportunities in ML Engineering, Quantitative Finance,
+                    and Data Science. If you're building something interesting, I'd love to hear about it.
                 </p>
                 <a href="mailto:nevynduarte@gmail.com" class="contact-email">nevynduarte@gmail.com</a>
                 <div class="contact-links">


### PR DESCRIPTION
### Motivation
- Make the resume website more informative and accurate by expanding Experience entries with fuller role descriptions and additional internships while providing fallbacks when logo assets are missing. 
- Surface more Education detail by adding a full M.S. program entry (dates, GPA, and extended coursework) and promoting certifications/coursework into compact mini-cards. 
- Improve site copy and navigation clarity in the hero/about/skills areas to better reflect current focus and tools.

### Description
- Updated `index.html` to expand the Experience section with many enriched role descriptions, split AMD internships into separate entries, add several earlier internships and student roles, and replace missing logo images with semantic placeholder `div.exp-logo.exp-logo-placeholder` elements. 
- Updated `index.html` to revise the Education section to `Master of Science — Data Science` (CU Boulder) with GPA `3.72`, extended coursework list, updated UT Austin coursework, added Regis High School card, and converted standalone credentials into multiple `edu-card--minor` mini-cards. 
- Updated `css/style.css` to increase `.exp-logo` width to `115px` and `.edu-logo` width to `138px`, and to add styling for `.exp-logo-placeholder`, `.edu-card--minor`, `.edu-minor-title`, and `.edu-minor-school`. 
- Minor content and layout tweaks across the page: hero/summary copy, skills lists, nav/menu labels, project/research section numbering, and added a visual screenshot artifact for verification.

### Testing
- Launched a local static server with `python -m http.server` and confirmed it started successfully. 
- Ran a Playwright script to load `http://localhost:8000/index.html` and capture a full-page screenshot to `artifacts/education-experience.png`, which completed successfully. 
- Verified changed files are staged and committed with `git commit` and inspected the updated `index.html`/`css/style.css` content using `nl`/`sed`/`git status`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973177259d08326892eda1f0b5dbaf7)